### PR TITLE
Add base profile pages

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "useTabs": false,
+  "tabWidth": 2,
   "singleQuote": true,
   "trailingComma": "none",
   "printWidth": 100,

--- a/messages/en.json
+++ b/messages/en.json
@@ -3,5 +3,8 @@
   "generic_error": "Something went wrong! Try again later :]",
 
   "global_leaderboards": "Global Leaderboards",
-  "profile": "Profile"
+  "profile": "Profile",
+
+  "best_plays": "Best Plays",
+  "recent_plays": "Recent Plays"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -2,5 +2,6 @@
   "loading": "Loading...",
   "generic_error": "Something went wrong! Try again later :]",
 
-  "global_leaderboards": "Global Leaderboards"
+  "global_leaderboards": "Global Leaderboards",
+  "profile": "Profile"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -2,5 +2,6 @@
   "loading": "Carregando...",
   "generic_error": "Desculpe, algo deu errado. Por favor, tente novamente mais tarde. :]",
 
-  "global_leaderboards": "Ranking mundial"
+  "global_leaderboards": "Ranking mundial",
+  "profile": "Perfil"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -3,5 +3,8 @@
   "generic_error": "Desculpe, algo deu errado. Por favor, tente novamente mais tarde. :]",
 
   "global_leaderboards": "Ranking mundial",
-  "profile": "Perfil"
+  "profile": "Perfil",
+
+  "best_plays": "Melhores Peças",
+  "recent_plays": "Peças Recentes"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1045,9 +1045,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001563",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001563.tgz",
-      "integrity": "sha512-na2WUmOxnwIZtwnFI2CZ/3er0wdNzU7hN+cPYz/z2ajHThnkWjNBOpEPP4n+4r2WPM847JaMotaJE3bnfzjyKw==",
+      "version": "1.0.30001679",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001679.tgz",
+      "integrity": "sha512-j2YqID/YwpLnKzCmBOS4tlZdWprXm3ZmQLBH9ZBXFOhoxLA46fwyBvx6toCBWBmnuwUY/qB3kEU6gFx8qgCroA==",
       "dev": true,
       "funding": [
         {
@@ -1062,7 +1062,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chokidar": {
       "version": "3.5.3",

--- a/src/lib/components/global-leaderboards/Table.svelte
+++ b/src/lib/components/global-leaderboards/Table.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
+  import { getFlagEmoji } from "$lib/utils/flags";
+
   type TableItem = {
     username: string;
     tt: number;
     rank: number;
     picture: string | null;
+    country: string;
+    id: number;
   };
 
   export let data: TableItem[];
+  export let lang: string = "en";
 </script>
 
 <div class="rounded border border-gray-800 bg-toot-red p-2 text-white">
@@ -16,25 +21,30 @@
       <div
         class="my-4 flex rounded border border-gray-800 bg-toot-pale-red p-5 text-center text-xl font-bold drop-shadow-lg"
       >
-        <div class="w-1/12">
-          <p>#{user.rank}</p>
+        <div class="flex w-1/12 justify-center place-content-center">
+          <p class="place-self-center">#{user.rank}</p>
         </div>
-        <div class="flex w-1/12 justify-center">
+        <div class="flex w-1/12 justify-center place-content-center">
+          <p class="text-2xl place-self-center">{getFlagEmoji(user.country)}</p>
+        </div>
+        <div class="flex w-1/12 justify-center place-content-center">
           {#if user.picture}
-            <img class="h-6" src={user.picture} alt={`${user.username}'s avatar`} />
+            <img class="h-10 w-10 object-contain rounded-full p-1" src={user.picture} alt={`${user.username}'s avatar`} />
           {:else}
             <img
-              class="h-8 w-8 rounded-full border border-gray-900 p-1"
+              class="h-10 w-10 object-contain rounded-full p-1"
               src="/tt_logo.svg"
               alt={`${user.username}'s avatar`}
             />
           {/if}
         </div>
-        <div class="w-8/12 text-center">
-          <p class="overflow-hidden overflow-ellipsis px-2">{user.username}</p>
+        <div class="flex w-7/12 justify-center place-content-center">
+          <a class="place-self-center" href="/{lang}/profile/{user.id}">
+            <p class="overflow-hidden overflow-ellipsis px-2">{user.username}</p>
+          </a>
         </div>
-        <div class="w-2/12 text-center">
-          <p>{user.tt.toFixed(2)}tt</p>
+        <div class="flex w-2/12 justify-center place-content-center">
+          <p class="place-self-center">{user.tt.toFixed(2)}tt</p>
         </div>
       </div>
     {/each}

--- a/src/lib/components/profile/Badge.svelte
+++ b/src/lib/components/profile/Badge.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import type { BadgeInfo } from '$lib/types/profile';
+
+  export let badge: BadgeInfo;
+</script>
+
+<div class="px-1">
+  <img src="{badge.image}" alt="{badge.alt_text}"/>
+</div>

--- a/src/lib/components/profile/PlayTable.svelte
+++ b/src/lib/components/profile/PlayTable.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import type { ProfileScore } from '$lib/types/score';
+
+  export let plays: ProfileScore[];
+</script>
+
+<div class="rounded border border-gray-800 bg-toot-red p-2 text-white">
+  {#if plays.length > 0}
+    {#each plays as play}
+      <div
+        class="my-4 flex rounded border border-gray-800 bg-toot-pale-red p-5 text-center text-xl drop-shadow-lg align-middle place-items-center"
+      >
+        <div class="w-1/12 text-center">
+          <p>{play.grade}</p>
+        </div>
+        <div class="w-2/12 text-center">
+          <p>{play.score}</p>
+          <p>{play.percentage.toFixed(2)}%</p>
+        </div>
+        <div class="w-6/12 text-center">
+          <p class="overflow-hidden overflow-ellipsis px-2">
+            <!-- TODO: Have this redirect to the SvelTally version of the song page -->
+            <a href="https://toottally.com/song/{play.song_id}/">{play.song_name}</a>
+          </p>
+        </div>
+        <div class="w-2/12 text-center">
+          <p>{play.replay_speed.toFixed(2)}x</p>
+          <p>{play.modifiers ?? ''}</p>
+        </div>
+        <div class="w-1/12 text-center">
+          <p>{play.tt.toFixed(2)}tt</p>
+        </div>
+      </div>
+    {/each}
+  {:else}
+    <p class="p-6 text-center font-title text-2xl">Loading...</p>
+  {/if}
+</div>
+

--- a/src/lib/components/profile/PlayTable.svelte
+++ b/src/lib/components/profile/PlayTable.svelte
@@ -2,9 +2,13 @@
   import type { ProfileScore } from '$lib/types/score';
 
   export let plays: ProfileScore[];
+  export let tableName: string;
 </script>
 
+<!-- TODO: Paginate play table data -->
+
 <div class="rounded border border-gray-800 bg-toot-red p-2 text-white">
+  <p class="m-2 p-2 text-2xl font-bold">{tableName}</p>
   {#if plays.length > 0}
     {#each plays as play}
       <div
@@ -33,7 +37,7 @@
       </div>
     {/each}
   {:else}
-    <p class="p-6 text-center font-title text-2xl">Loading...</p>
+    <p class="p-6 text-center font-title text-2xl">No plays found!</p>
   {/if}
 </div>
 

--- a/src/lib/components/profile/ProfileCard.svelte
+++ b/src/lib/components/profile/ProfileCard.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import type { ProfileBaseResponse } from "$lib/types/profile";
+  import { getFlagEmoji } from "$lib/utils/flags";
+
+  export let user: ProfileBaseResponse;
+</script>
+
+<div>
+  <!-- TODO: Actually implement this card to pop up on user hovers -->
+</div>

--- a/src/lib/components/profile/ProfileHeader.svelte
+++ b/src/lib/components/profile/ProfileHeader.svelte
@@ -1,15 +1,7 @@
 <script lang="ts">
   import type { ProfileBaseResponse } from "$lib/types/profile";
+  import { getFlagEmoji } from "$lib/utils/flags";
   import Badge from "./Badge.svelte";
-
-  // Code taken from https://dev.to/jorik/country-code-to-flag-emoji-a21
-  function getFlagEmoji(countryCode: string) {
-    const codePoints = countryCode
-      .toUpperCase()
-      .split('')
-      .map(char =>  127397 + char.charCodeAt(0));
-    return String.fromCodePoint(...codePoints);
-  }
 
   export let user: ProfileBaseResponse;
 </script>

--- a/src/lib/components/profile/ProfileHeader.svelte
+++ b/src/lib/components/profile/ProfileHeader.svelte
@@ -1,18 +1,42 @@
 <script lang="ts">
   import type { ProfileBaseResponse } from "$lib/types/profile";
+  import Badge from "./Badge.svelte";
+
+  // Code taken from https://dev.to/jorik/country-code-to-flag-emoji-a21
+  function getFlagEmoji(countryCode: string) {
+    const codePoints = countryCode
+      .toUpperCase()
+      .split('')
+      .map(char =>  127397 + char.charCodeAt(0));
+    return String.fromCodePoint(...codePoints);
+  }
 
   export let user: ProfileBaseResponse;
 </script>
 
 <div class="rounded border border-gray-800 bg-toot-red p-2 text-white">
-  {#if user.picture}
-    <img class="h-6" src={user.picture} alt={`${user.username}'s avatar`} />
-  {:else}
-    <img
-      class="h-8 w-8 rounded-full border border-gray-900 p-1"
-      src="/tt_logo.svg"
-      alt={`${user.username}'s avatar`}
-    />
-  {/if}
-  <p class="py-2 text-3xl font-bold">{user.username} (#{user.rank} {user.tt.toFixed(2)}tt)</p>
+  <div class="my-4 px-2 flex flex-col">
+    <div class="w-full grid grid-cols-6">
+      <div class="grid col-span-1">
+        {#if user.picture}
+          <img class="object-fill h-40 w-40 rounded-full border" src={user.picture} alt={`${user.username}'s avatar`} />
+        {:else}
+          <img
+            class="object-fill h-40 w-40 rounded-full border border-gray-900 p-1"
+            src="/tt_logo.svg"
+            alt={`${user.username}'s avatar`}
+          />
+        {/if}
+      </div>
+      <div class="grid col-span-5 content-start">
+        <p class="py-2 text-3xl font-bold">{getFlagEmoji(user.country)} {user.username} (#{user.rank})</p>
+        <p class="text-xl">{user.tt.toFixed(2)}tt</p>
+      </div>
+    </div>
+    <div class="pt-4 w-full flex flex-row">
+      {#each user.badges as badge}
+        <Badge badge={badge}/>
+      {/each}
+    </div>
+  </div>
 </div>

--- a/src/lib/components/profile/ProfileHeader.svelte
+++ b/src/lib/components/profile/ProfileHeader.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import type { ProfileBaseResponse } from "$lib/types/profile";
+
+  export let user: ProfileBaseResponse;
+</script>
+
+<div class="rounded border border-gray-800 bg-toot-red p-2 text-white">
+  {#if user.picture}
+    <img class="h-6" src={user.picture} alt={`${user.username}'s avatar`} />
+  {:else}
+    <img
+      class="h-8 w-8 rounded-full border border-gray-900 p-1"
+      src="/tt_logo.svg"
+      alt={`${user.username}'s avatar`}
+    />
+  {/if}
+  <p class="py-2 text-3xl font-bold">{user.username} (#{user.rank} {user.tt.toFixed(2)}tt)</p>
+</div>

--- a/src/lib/types/profile.ts
+++ b/src/lib/types/profile.ts
@@ -1,0 +1,44 @@
+import type { SongInfo } from "./song";
+
+export type ProfileBaseResponse = {
+  id: number;
+  username: string;
+  rank: number;
+  country: string;
+  account_standing: AccountStanding;
+  tt: number;
+  status: Status;
+  picture: string | null;
+  currently_playing: SongInfo[] | null;
+  badges: BadgeInfo[];
+  dev: boolean;
+  rating_team: boolean;
+  supporter: boolean;
+  beta_tester: boolean;
+  moderator: boolean;
+};
+
+export type BadgeInfo = {
+  name: string;
+  alt_text: string;
+  image: string;
+  image_2x: string;
+  image_4x: string;
+};
+
+export enum Status {
+  OFFLINE = "Offline",
+  ONLINE = "Online",
+  IDLE = "Idle",
+  MAIN_MENU = "Main Menu",
+  BROWSING_SONGS = "Browsing Songs",
+  PLAYING = "Playing",
+  WATCHING_REPLAY = "Watching Replay",
+  SPECTATING = "Spectating",
+};
+
+export enum AccountStanding {
+  GOOD = "Good Standing",
+  RESTRICTED = "Restricted",
+  BANNED = "Banned",
+}

--- a/src/lib/types/profile.ts
+++ b/src/lib/types/profile.ts
@@ -24,6 +24,7 @@ export type BadgeInfo = {
   image: string;
   image_2x: string;
   image_4x: string;
+  badge_type: BadgeType;
 };
 
 export enum Status {
@@ -41,4 +42,9 @@ export enum AccountStanding {
   GOOD = "Good Standing",
   RESTRICTED = "Restricted",
   BANNED = "Banned",
+}
+
+export enum BadgeType {
+  PLAYER = 0,
+  CHARTER = 1,
 }

--- a/src/lib/types/score.ts
+++ b/src/lib/types/score.ts
@@ -1,0 +1,66 @@
+export type APIScoreResponse = {
+  count: number;
+  next: string;
+  previous: string;
+  results: ProfileScore[];
+}
+
+export type ProfileScore = {
+  score: number;
+  player_id: number;
+  player: string;
+  played_on: string;
+  tt: number;
+  grade: "S" | "A" | "B" | "C" | "D" | "F";
+  perfect: number;
+  nice: number;
+  okay: number;
+  meh: number;
+  nasty: number;
+  max_combo?: number;
+  percentage: number;
+  game_version: string;
+  replay_id: string;
+  song_id: number;
+  song_name: string;
+  song_artist: string;
+  song_notehash: string;
+  song_filehash: string;
+  song_is_rated: boolean;
+  replay_speed: number;
+  difficulty: number;
+  modifiers: Modifier[] | null;
+}
+
+export type SongLeaderboardScoreResponse = {
+  score: number;
+  player_id: number;
+  player: string;
+  played_on: string;
+  grade: "S" | "A" | "B" | "C" | "D" | "F";
+  perfect: number;
+  nice: number;
+  okay: number;
+  meh: number;
+  nasty: number;
+  max_combo: number;
+  percentage: number;
+  game_version: string;
+  replay_id: string;
+  tt: number;
+  is_rated: boolean;
+  replay_speed: number;
+  difficulty: number;
+  modifiers: Modifier[] | null;
+}
+
+export enum Modifier {
+  HIDDEN = "HD",
+  FLASHLIGHT = "FL",
+  BRUTAL = "BT",
+  INSTAFAIL = "IF",
+  EASY = "EZ",
+  STRICT = "ST",
+  AUTOTUNE = "AT",
+  HIDDEN_CURSOR = "HC",
+}

--- a/src/lib/types/song.ts
+++ b/src/lib/types/song.ts
@@ -1,0 +1,31 @@
+export type SongInfo = {
+  id: number;
+  name: string;
+  short_name: string;
+  track_ref: string;
+  note_hash: string;
+  file_hash: string;
+  alt_downloads: string[];
+  difficulty: number;
+  tap: number;
+  aim: number;
+  acc: number;
+  base_tt: number;
+  uploaded_at: string;
+  author: string;
+  charter: string;
+  download: string | null;
+  mirror: string | null;
+  is_official: boolean;
+  play_count: number;
+  max_score: number;
+  s_rank_score: number;
+  is_rated: boolean;
+  speed_diffs: number[];
+  speed_taps: number[];
+  speed_aim: number[];
+  speed_acc: number[];
+  song_length: number;
+  note_count: number;
+  status: "WORK_IN_PROGRESS" | "UNRATED" | "REQUEST_REVIEW" | "RATED" | "LOVED";
+}

--- a/src/lib/utils/flags.ts
+++ b/src/lib/utils/flags.ts
@@ -1,0 +1,10 @@
+// flags.ts - Utility functions for handling stuff with country flags
+
+// Code taken from https://dev.to/jorik/country-code-to-flag-emoji-a21
+export function getFlagEmoji(countryCode: string) {
+  const codePoints = countryCode
+    .toUpperCase()
+    .split('')
+    .map(char =>  127397 + char.charCodeAt(0));
+  return String.fromCodePoint(...codePoints);
+}

--- a/src/params/profileId.ts
+++ b/src/params/profileId.ts
@@ -1,0 +1,3 @@
+export function match(param) {
+  return /^[0-9]$/.test(param);
+}

--- a/src/params/profileId.ts
+++ b/src/params/profileId.ts
@@ -1,3 +1,3 @@
 export function match(param) {
-  return /^[0-9]$/.test(param);
+  return /^[0-9]+$/.test(param);
 }

--- a/src/routes/[[lang=lang]]/+page.svelte
+++ b/src/routes/[[lang=lang]]/+page.svelte
@@ -24,7 +24,10 @@
     />
 
     {#if resolvedData.results?.length > 0}
-      <Table data={resolvedData.results} />
+      <Table
+        data={resolvedData.results}
+        lang={data.lang ?? "en"}
+      />
     {/if}
 
     <Pagination

--- a/src/routes/[[lang=lang]]/+page.ts
+++ b/src/routes/[[lang=lang]]/+page.ts
@@ -15,12 +15,16 @@ type LeaderboardResponse = {
   }[];
 };
 
-export const load: PageLoad = ({ url, fetch }) => {
-  const params = url.searchParams;
-  const page = params.get('page') ? Number(params.get('page')) : 1;
+export const load: PageLoad = ({ url, fetch, params }) => {
+  const urlParams = url.searchParams;
+  const page = urlParams.get('page') ? Number(urlParams.get('page')) : 1;
   const query: Promise<LeaderboardResponse> = fetch(
     `${PUBLIC_API_URL}/globalleaderboard/?page=${page}`
   ).then((res) => res.json());
 
-  return { page, promise: { query } };
+  return {
+    page: page,
+    lang: params.lang,
+    promise: { query },
+  };
 };

--- a/src/routes/[[lang=lang]]/profile/[[id=profileId]]/+error.svelte
+++ b/src/routes/[[lang=lang]]/profile/[[id=profileId]]/+error.svelte
@@ -1,0 +1,8 @@
+<script>
+  import MainLayout from '$lib/components/MainLayout.svelte';
+  import * as m from '$paraglide/messages';
+</script>
+
+<MainLayout>
+  <p class="p-8 text-center font-title text-2xl">{m.generic_error()}</p>
+</MainLayout>

--- a/src/routes/[[lang=lang]]/profile/[[id=profileId]]/+page.svelte
+++ b/src/routes/[[lang=lang]]/profile/[[id=profileId]]/+page.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import MainLayout from '$lib/components/MainLayout.svelte';
+  import ProfileHeader from '$lib/components/profile/ProfileHeader.svelte';
+  import * as m from '$paraglide/messages';
+
+  import type { PageData } from './$types';
+
+  export let data: PageData;
+</script>
+
+<MainLayout>
+  {#await data.promise.query}
+    <p class="p-8 text-center font-title text-2xl">{m.loading()}</p>
+  {:then resolvedData}
+    <ProfileHeader user={resolvedData}/>
+  {/await}
+</MainLayout>

--- a/src/routes/[[lang=lang]]/profile/[[id=profileId]]/+page.svelte
+++ b/src/routes/[[lang=lang]]/profile/[[id=profileId]]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import MainLayout from '$lib/components/MainLayout.svelte';
+  import PlayTable from '$lib/components/profile/PlayTable.svelte';
   import ProfileHeader from '$lib/components/profile/ProfileHeader.svelte';
   import * as m from '$paraglide/messages';
 
@@ -9,9 +10,23 @@
 </script>
 
 <MainLayout>
-  {#await data.promise.query}
+  {#await data.promises.query}
     <p class="p-8 text-center font-title text-2xl">{m.loading()}</p>
   {:then resolvedData}
-    <ProfileHeader user={resolvedData}/>
+    <ProfileHeader user={resolvedData[0]}/>
+
+    <hr/>
+    {#if resolvedData[2].count > 0}
+      <PlayTable plays={resolvedData[2].results}/>
+    {:else}
+      <p>No plays found.</p>
+    {/if}
+    
+    <hr/>
+    {#if resolvedData[1].count > 0}
+      <PlayTable plays={resolvedData[1].results}/>
+    {:else}
+      <p>No plays found.</p>
+    {/if}
   {/await}
 </MainLayout>

--- a/src/routes/[[lang=lang]]/profile/[[id=profileId]]/+page.svelte
+++ b/src/routes/[[lang=lang]]/profile/[[id=profileId]]/+page.svelte
@@ -16,17 +16,15 @@
     <ProfileHeader user={resolvedData[0]}/>
 
     <hr/>
-    {#if resolvedData[2].count > 0}
-      <PlayTable plays={resolvedData[2].results}/>
-    {:else}
-      <p>No plays found.</p>
-    {/if}
+    <PlayTable
+      tableName={m.best_plays()}
+      plays={resolvedData[2].results}
+    />
     
     <hr/>
-    {#if resolvedData[1].count > 0}
-      <PlayTable plays={resolvedData[1].results}/>
-    {:else}
-      <p>No plays found.</p>
-    {/if}
+    <PlayTable
+      tableName={m.recent_plays()}
+      plays={resolvedData[1].results}
+    />
   {/await}
 </MainLayout>

--- a/src/routes/[[lang=lang]]/profile/[[id=profileId]]/+page.ts
+++ b/src/routes/[[lang=lang]]/profile/[[id=profileId]]/+page.ts
@@ -16,5 +16,10 @@ export const load: PageLoad = ({ params, fetch }) => {
     `${PUBLIC_API_URL}/profile/${params.id}/best_scores/`
   ).then((res) => res.json());
 
-  return { promises: { query: Promise.all([profile, recentScores, bestScores]) } };
+  return {
+    promises: {
+      query: Promise.all([profile, recentScores, bestScores]) 
+    },
+    lang: params.lang,
+  };
 };

--- a/src/routes/[[lang=lang]]/profile/[[id=profileId]]/+page.ts
+++ b/src/routes/[[lang=lang]]/profile/[[id=profileId]]/+page.ts
@@ -1,0 +1,11 @@
+import type { PageLoad } from './$types';
+import { PUBLIC_API_URL } from '$env/static/public';
+import type { ProfileBaseResponse } from '$lib/types/profile';
+
+export const load: PageLoad = ({ params, fetch }) => {
+  const query: Promise<ProfileBaseResponse> = fetch(
+    `${PUBLIC_API_URL}/profile/${params.id}`
+  ).then((res) => res.json());
+
+  return { promise: { query } };
+};

--- a/src/routes/[[lang=lang]]/profile/[[id=profileId]]/+page.ts
+++ b/src/routes/[[lang=lang]]/profile/[[id=profileId]]/+page.ts
@@ -1,11 +1,20 @@
 import type { PageLoad } from './$types';
 import { PUBLIC_API_URL } from '$env/static/public';
 import type { ProfileBaseResponse } from '$lib/types/profile';
+import type { APIScoreResponse } from '$lib/types/score';
 
 export const load: PageLoad = ({ params, fetch }) => {
-  const query: Promise<ProfileBaseResponse> = fetch(
-    `${PUBLIC_API_URL}/profile/${params.id}`
+  const profile: Promise<ProfileBaseResponse> = fetch(
+    `${PUBLIC_API_URL}/profile/${params.id}/`
   ).then((res) => res.json());
 
-  return { promise: { query } };
+  const recentScores: Promise<APIScoreResponse> = fetch(
+    `${PUBLIC_API_URL}/profile/${params.id}/recent_scores/`
+  ).then((res) => res.json());
+
+  const bestScores: Promise<APIScoreResponse> = fetch(
+    `${PUBLIC_API_URL}/profile/${params.id}/best_scores/`
+  ).then((res) => res.json());
+
+  return { promises: { query: Promise.all([profile, recentScores, bestScores]) } };
 };


### PR DESCRIPTION
This is a very basic and rudimentary profile page. It's very much missing some features compared to the [current version](https://toottally.com/profile/1/), but this should get the ball rolling.


### What's been implemented in this PR that's related to profiles
  - [x] Profile picture
  - [x] TT + Rank
  - [x] Redirection from leaderboard page
  - [x] Play tables (both top 50 best and 50 most recent plays)
  - [x] Country Flags (as emoji)


### What's been implemented in this PR that's NOT related to profiles
  - [x] Show country in leaderboard
  - [x] Align all elements in leaderboard table
  - [x] Update browsers list DB version
  - [x] Enforce 2 space tab width in `.prettierrc`


### What needs to be implemented in the future
  - [ ] Rank graphs
  - [ ] Pagination for play tables
  - [ ] Collapse play tables


### What would be nice to have (probably)
  - [ ] Quick Nav to plays
  - [ ] Possible redesign by someone that's actually qualified (aka not me)
  - [ ] Re-check translation files (I used Google Translate lol)
  - [ ] Update to Svelte 5 (might take a while, idk)
  - [ ] Adopt a country library for flags?


### What it looks like
![image](https://github.com/user-attachments/assets/180fdedb-6474-42b1-b06e-d8928b6a58ec)

![image](https://github.com/user-attachments/assets/39ddb66c-f7ae-4978-9f1a-6bc617c7cd62)

![image](https://github.com/user-attachments/assets/321d09d2-9c63-470f-a0ed-ae0f0e3fbd11)
